### PR TITLE
[update] 커스텀 에러 처리

### DIFF
--- a/src/main/java/com/example/twogether/board/service/BoardColService.java
+++ b/src/main/java/com/example/twogether/board/service/BoardColService.java
@@ -64,14 +64,11 @@ public class BoardColService {
 
         // 보드를 생성한 사람만 협업자 추방하기 가능
         if (!foundBoard.getUser().getId().equals(user.getId()) || !user.getRole().equals(UserRoleEnum.ADMIN)) {
-
-            log.error("보드를 생성한 사람만 협업자 추방할 수 있습니다.");
             throw new CustomException(CustomErrorCode.NOT_YOUR_BOARD);
         }
 
         // 보드 오너는 초대당하기 불가 - 해당 사항에 대해 추후 프론트에서 예외처리되면 삭제될 예정
         if (email.equals(user.getEmail())) {
-            log.error("보드 오너는 초대할 수 없습니다.");
             throw new CustomException(CustomErrorCode.THIS_IS_YOUR_BOARD);
         }
 

--- a/src/main/java/com/example/twogether/common/dto/ErrorResponseDto.java
+++ b/src/main/java/com/example/twogether/common/dto/ErrorResponseDto.java
@@ -1,0 +1,35 @@
+package com.example.twogether.common.dto;
+
+import com.example.twogether.common.error.CustomErrorCode;
+import com.example.twogether.common.exception.CustomException;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ErrorResponseDto {
+    private final int status;
+    private final String code;
+    private final String message;
+
+    public ErrorResponseDto(CustomErrorCode errorCode) {
+        this.status = HttpStatus.BAD_REQUEST.value();
+        this.code = errorCode.getCode();
+        this.message = errorCode.getErrorMessage();
+    }
+
+    public static ResponseEntity<ErrorResponseDto> error(CustomException e) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponseDto.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .code(e.getErrorCode().getCode())
+                .message(e.getErrorCode().getErrorMessage())
+                .build());
+    }
+}

--- a/src/main/java/com/example/twogether/common/error/CustomErrorCode.java
+++ b/src/main/java/com/example/twogether/common/error/CustomErrorCode.java
@@ -55,11 +55,11 @@ public enum CustomErrorCode {
     CARD_LABEL_NOT_FOUND("CL002", "해당 카드에 등록되지 않은 라벨입니다."),
     ;
 
-    private final String errorCode;
+    private final String code;
     private final String errorMessage;
 
-    CustomErrorCode(String errorCode, String errorMessage) {
-        this.errorCode = errorCode;
+    CustomErrorCode(String code, String errorMessage) {
+        this.code = code;
         this.errorMessage = errorMessage;
     }
 }

--- a/src/main/java/com/example/twogether/common/exception/CustomException.java
+++ b/src/main/java/com/example/twogether/common/exception/CustomException.java
@@ -15,7 +15,6 @@ public class CustomException extends RuntimeException {
 
     public CustomException(CustomErrorCode errorCode) {
         super(errorCode.getErrorMessage());
-        log.error(errorCode.getErrorMessage());
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/example/twogether/common/exception/CustomException.java
+++ b/src/main/java/com/example/twogether/common/exception/CustomException.java
@@ -2,9 +2,11 @@ package com.example.twogether.common.exception;
 
 import com.example.twogether.common.error.CustomErrorCode;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+@Slf4j
 @Getter
 @ResponseStatus(value = HttpStatus.BAD_REQUEST)
 public class CustomException extends RuntimeException {
@@ -13,6 +15,7 @@ public class CustomException extends RuntimeException {
 
     public CustomException(CustomErrorCode errorCode) {
         super(errorCode.getErrorMessage());
+        log.error(errorCode.getErrorMessage());
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/example/twogether/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/example/twogether/common/exception/GlobalControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.example.twogether.common.exception;
 
 import com.example.twogether.common.dto.ApiResponseDto;
+import com.example.twogether.common.dto.ErrorResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,10 +15,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalControllerAdvice {
 
     @ExceptionHandler({CustomException.class})
-    public ResponseEntity<ApiResponseDto> handlerCustomException(CustomException e) {
-        ApiResponseDto restApiException = new ApiResponseDto(HttpStatus.BAD_REQUEST.value(),
-            e.getMessage());
-        return ResponseEntity.badRequest().body(restApiException);
+    public ResponseEntity<ErrorResponseDto> handlerCustomException(CustomException e) {
+        log.error("[CustomException] {} : {}",e.getErrorCode().getCode(), e.getErrorCode().getErrorMessage());
+        return ErrorResponseDto.error(e);
     }
 
     @ExceptionHandler({MethodArgumentNotValidException.class})


### PR DESCRIPTION
## 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->

* #68

## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

* 커스텀 에러가 발생했을 때 터미널에 에러 메시지를 출력하도록 일괄 처리
* 기존에 추가되어있던 log.error들이 필요없어져서 지우기
* log.error를 지우는 김에 최종 프로젝트에는 필요 없는 log.info 지우기 < 상의 후 결정 (BoardService에만 존재)
* 상태코드는 프론트와 서버가 소통하기 위한 규약이니 굳이 바꾸기보단 커스텀 에러코드를 추가로 반환하는 형태로 수정
* log.error를 CustomError 생성자가 아닌 Handler에서 호출하도록 수정 및 메시지 수정
* 기존 커스텀 에러 코드의 필드명을 errorCode라고 했는데 클래스명과 너무 유사해 code로 수정

## Todo List

<!-- 이번 Pull Request 작업에서 아직 처리하지 못한 작업이나  
    추후에 해결해야 될 문제들을 기입해 주세요 -->  



## Check List

<!-- 기능 구현을 다 했다면? --> 

- [x] 포스트맨으로 체크해 보았나요?
- [ ] 테스트 코드를 작성하셨나요?

<!-- 기능 구현을 다 못했다면? -->

- [ ] 다른 팀원의 PR을 보고 코드 리뷰를 남겨 보았나요?
- [x] PR 수고하셨습니다!!

## 트러블 슈팅

<!-- 있었던 오류나 발생했던 예외에 대해서 기록해 보세요 -->  

* 기존에는 에러가 발생할 때마다 log.error를 추가해서 일일이 어떤 에러코드의 메시지를 반환할지 붙여줬어야 했는데, 그렇게 하려다 보니 find~~ 메서드는 orElseThrow()를 통해 예외처리를 해서 미리 isEmpty를 통해 log.error를 미리 던져줘야 하는 비효율적이고 귀찮은 작업을 해줬어야 했다. 그러다가 커스텀 에러는 어차피 CustomException 생성자를 통해 반환하니까, 생성자를 호출할 때 log.error를 호출하면 모든 에러에서 일괄처리가 가능하다는 것을 깨닫고 이와 같이 수정했다.


기존 코드

```
if (!foundBoard.getUser().getId().equals(user.getId()) || !user.getRole().equals(UserRoleEnum.ADMIN)) {
    log.error("보드를 생성한 사람만 협업자 추방할 수 있습니다.");
    throw new CustomException(CustomErrorCode.NOT_YOUR_BOARD);
}
```

수정한 코드

```
if (!foundBoard.getUser().getId().equals(user.getId()) || !user.getRole().equals(UserRoleEnum.ADMIN)) {
    throw new CustomException(CustomErrorCode.NOT_YOUR_BOARD);
}

// CustomException
public CustomException(CustomErrorCode errorCode) {
    super(errorCode.getErrorMessage());
    log.error(errorCode.getErrorMessage());
    this.errorCode = errorCode;
}
```

* 워크스페이스 협업자 초대 메서드에서 예외처리를 throw new ~~Excepiton이 아닌 log.error로 하시는 것을 발견해서 추후 어떻게 할 지에 대해 생각해보기로 했다.

```
// WpColService
public void inviteWpCol(User user, Long wpId, String email) {
...
if (boardColRepository.existsByBoardAndEmail(foundBoard,
    foundUser.getEmail())) {
    log.error("워크스페이스에 포함된 보드 중 이미 협업자가 등록된 경우가 있습니다.");
    continue;
}
...
```