### PR TITLE
[update] 협업자로 초대된 워크스페이스, 보드 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/twogether/board/controller/BoardColController.java
+++ b/src/main/java/com/example/twogether/board/controller/BoardColController.java
@@ -1,17 +1,23 @@
 package com.example.twogether.board.controller;
 
 import com.example.twogether.board.dto.BoardColRequestDto;
+import com.example.twogether.board.dto.BoardResponseDto;
+import com.example.twogether.board.dto.BoardsResponseDto;
 import com.example.twogether.board.service.BoardColService;
 import com.example.twogether.common.dto.ApiResponseDto;
 import com.example.twogether.common.security.UserDetailsImpl;
+import com.example.twogether.workspace.dto.WpResponseDto;
+import com.example.twogether.workspace.dto.WpsResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -50,5 +56,28 @@ public class BoardColController {
     ) {
         boardColService.outBoardCol(userDetails.getUser(), wpId, boardId, boardColRequestDto.getEmail());
         return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "보드에서 협업자를 추방하였습니다."));
+    }
+
+    @Operation(summary = "초대된 보드 단건 조회")
+    @GetMapping("/workspaces/{wpId}/boards/{boardId}/invite")
+    public ResponseEntity<BoardResponseDto> getInvitedBoard(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable Long wpId,
+        @PathVariable Long boardId
+    ) {
+
+        BoardResponseDto invitedBoard = boardColService.getBoardCol(userDetails.getUser(), wpId, boardId);
+        return ResponseEntity.status(HttpStatus.OK).body(invitedBoard);
+    }
+
+    @Operation(summary = "초대된 보드 전체 조회")
+    @GetMapping("/workspaces/{wpId}/boards/invite")
+    public ResponseEntity<BoardsResponseDto> getInvitedBoards(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable Long wpId
+    ) {
+
+        BoardsResponseDto invitedBoards = boardColService.getBoardCols(userDetails.getUser(), wpId);
+        return ResponseEntity.status(HttpStatus.OK).body(invitedBoards);
     }
 }

--- a/src/main/java/com/example/twogether/board/controller/BoardColController.java
+++ b/src/main/java/com/example/twogether/board/controller/BoardColController.java
@@ -49,7 +49,6 @@ public class BoardColController {
         @RequestBody BoardColRequestDto boardColRequestDto
     ) {
         boardColService.outBoardCol(userDetails.getUser(), wpId, boardId, boardColRequestDto.getEmail());
-        return ResponseEntity.ok()
-            .body(new ApiResponseDto(HttpStatus.OK.value(), "보드에서 협업자를 추방하였습니다."));
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "보드에서 협업자를 추방하였습니다."));
     }
 }

--- a/src/main/java/com/example/twogether/board/controller/BoardController.java
+++ b/src/main/java/com/example/twogether/board/controller/BoardController.java
@@ -48,7 +48,6 @@ public class BoardController {
     @Operation(summary = "칸반 보드 수정")
     @PatchMapping("/workspaces/{wpId}/boards/{boardId}")
     public ResponseEntity<ApiResponseDto> editBoard(
-        @AuthenticationPrincipal UserDetailsImpl userDetails, // 이럴 때 고민..
         @PathVariable Long wpId,
         @PathVariable Long boardId,
         @RequestBody BoardRequestDto boardRequestDto
@@ -78,7 +77,6 @@ public class BoardController {
     @Operation(summary = "칸반 보드 단건 조회")
     @GetMapping("/workspaces/{wpId}/boards/{boardId}")
     public ResponseEntity<BoardResponseDto> getBoard(
-        @AuthenticationPrincipal UserDetailsImpl userDetails, // 이럴 때 고민
         @PathVariable Long wpId,
         @PathVariable Long boardId
     ) {

--- a/src/main/java/com/example/twogether/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/example/twogether/board/dto/BoardResponseDto.java
@@ -2,6 +2,7 @@ package com.example.twogether.board.dto;
 
 import com.example.twogether.board.entity.Board;
 import com.example.twogether.deck.dto.DeckResponseDto;
+import com.example.twogether.user.entity.User;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,16 +11,19 @@ import lombok.Getter;
 @Builder
 public class BoardResponseDto {
     private Long boardId;
+    private String email;
     private String nickname;
     private String title;
     private String color;
     private String info;
+
     private List<BoardColResponseDto> boardCollaborators;
     private List<DeckResponseDto> decks;
 
     public static BoardResponseDto of(Board board) {
         return BoardResponseDto.builder()
             .boardId(board.getId())
+            .email(board.getUser().getEmail())
             .nickname(board.getUser().getNickname())
             .title(board.getTitle())
             .color(board.getColor())

--- a/src/main/java/com/example/twogether/board/repository/BoardColRepository.java
+++ b/src/main/java/com/example/twogether/board/repository/BoardColRepository.java
@@ -2,6 +2,7 @@ package com.example.twogether.board.repository;
 
 import com.example.twogether.board.entity.Board;
 import com.example.twogether.board.entity.BoardCollaborator;
+import com.example.twogether.user.entity.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,5 @@ public interface BoardColRepository extends JpaRepository<BoardCollaborator, Lon
     List<BoardCollaborator> findByBoard(Board board);
     boolean existsByBoardAndEmail(Board board, String email);
     Optional<BoardCollaborator> findByBoardAndEmail(Board board, String email);
+    List<BoardCollaborator> findByUser(User user);
 }

--- a/src/main/java/com/example/twogether/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/twogether/board/repository/BoardRepository.java
@@ -9,8 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<List<Board>> findAllByWorkspace(Workspace workspace);
-
     Optional<Board> findByWorkspaceAndId(Workspace workspace, Long boardId);
-
     Optional<Board> findByWorkspace_IdAndId(Long workspaceId, Long boardId);
+    Optional<Board> findByWorkspace_IdAndIdAndAndBoardCollaborators_Email(Long id, Long boardId, String email);
+    List<Board> findAllBoardsByWorkspace_IdAndBoardCollaborators_Email(Long wpId, String email);
 }

--- a/src/main/java/com/example/twogether/board/service/BoardColService.java
+++ b/src/main/java/com/example/twogether/board/service/BoardColService.java
@@ -64,7 +64,8 @@ public class BoardColService {
         Board foundBoard = findBoard(foundWorkspace, boardId);
 
         // 보드를 생성한 사람만 협업자 추방하기 가능
-        if (!user.getId().equals(foundBoard.getUser().getId()) || !user.getRole().equals(UserRoleEnum.ADMIN)) {
+        if (!user.getId().equals(foundBoard.getUser().getId()) &&
+            !user.getRole().equals(UserRoleEnum.ADMIN)) {
 
             log.error("보드를 생성한 사람만 협업자 추방할 수 있습니다.");
             throw new CustomException(CustomErrorCode.NOT_YOUR_BOARD);

--- a/src/main/java/com/example/twogether/board/service/BoardColService.java
+++ b/src/main/java/com/example/twogether/board/service/BoardColService.java
@@ -64,7 +64,7 @@ public class BoardColService {
         Board foundBoard = findBoard(foundWorkspace, boardId);
 
         // 보드를 생성한 사람만 협업자 추방하기 가능
-        if (!user.getId().equals(foundBoard.getUser().getId()) &&
+        if (!foundWorkspace.getUser().getId().equals(user.getId()) &&
             !user.getRole().equals(UserRoleEnum.ADMIN)) {
 
             log.error("보드를 생성한 사람만 협업자 추방할 수 있습니다.");
@@ -73,12 +73,12 @@ public class BoardColService {
 
         // 보드 오너는 초대당하기 불가 - 해당 사항에 대해 추후 프론트에서 예외처리되면 삭제될 예정
         if (email.equals(user.getEmail())) {
-            log.error("보드 오너는 초대할 수 없습니다.");
+            log.error("보드의 오너는 초대할 수 없습니다.");
             throw new CustomException(CustomErrorCode.THIS_IS_YOUR_BOARD);
         }
 
         // 보드 협업자 삭제
-        BoardCollaborator foundBoardCol = findBoardCol(foundBoard, email);
+        BoardCollaborator foundBoardCol = findBoardColByEmail(foundBoard, email);
         boardColRepository.delete(foundBoardCol);
     }
 
@@ -94,7 +94,7 @@ public class BoardColService {
             new CustomException(CustomErrorCode.BOARD_NOT_FOUND));
     }
 
-    private BoardCollaborator findBoardCol(Board board, String email) {
+    private BoardCollaborator findBoardColByEmail(Board board, String email) {
 
         return boardColRepository.findByBoardAndEmail(board, email).orElseThrow(() ->
             new CustomException(CustomErrorCode.BOARD_COLLABORATOR_NOT_FOUND));

--- a/src/main/java/com/example/twogether/board/service/BoardColService.java
+++ b/src/main/java/com/example/twogether/board/service/BoardColService.java
@@ -33,9 +33,11 @@ public class BoardColService {
 
         Workspace foundWorkspace = findWorkspace(wpId);
         Board foundBoard = findBoard(foundWorkspace, boardId);
+        User foundUser = findUser(email);
 
         // 보드를 생성한 사람만 협업자 초대하기 가능
-        if (!foundBoard.getUser().getId().equals(user.getId()) || !user.getRole().equals(UserRoleEnum.ADMIN)) {
+        if (!foundBoard.getUser().getId().equals(user.getId()) &&
+            !user.getRole().equals(UserRoleEnum.ADMIN)) {
             throw new CustomException(CustomErrorCode.NOT_YOUR_BOARD);
         }
 
@@ -50,8 +52,7 @@ public class BoardColService {
         }
 
         // 보드 협업자로 등록
-        User findUser = findUser(email);
-        BoardCollaborator foundBoardCol = BoardColRequestDto.toEntity(findUser, foundBoard);
+        BoardCollaborator foundBoardCol = BoardColRequestDto.toEntity(foundUser, foundBoard);
         boardColRepository.save(foundBoardCol);
     }
 
@@ -63,7 +64,7 @@ public class BoardColService {
         Board foundBoard = findBoard(foundWorkspace, boardId);
 
         // 보드를 생성한 사람만 협업자 추방하기 가능
-        if (!foundBoard.getUser().getId().equals(user.getId()) || !user.getRole().equals(UserRoleEnum.ADMIN)) {
+        if (!user.getId().equals(foundBoard.getUser().getId()) || !user.getRole().equals(UserRoleEnum.ADMIN)) {
 
             log.error("보드를 생성한 사람만 협업자 추방할 수 있습니다.");
             throw new CustomException(CustomErrorCode.NOT_YOUR_BOARD);

--- a/src/main/java/com/example/twogether/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/twogether/common/config/WebSecurityConfig.java
@@ -57,7 +57,6 @@ public class WebSecurityConfig {
             authorizeHttpRequests
                 .requestMatchers(HttpMethod.POST, "/api/users/**").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/**").permitAll()
-                .requestMatchers("/api/workspaces/**").permitAll()
                 .requestMatchers("/api/boards/**").permitAll()
                 .requestMatchers("/api/decks/**").permitAll()
                 .requestMatchers("api/cards/**").permitAll()

--- a/src/main/java/com/example/twogether/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/twogether/common/config/WebSecurityConfig.java
@@ -57,6 +57,7 @@ public class WebSecurityConfig {
             authorizeHttpRequests
                 .requestMatchers(HttpMethod.POST, "/api/users/**").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/**").permitAll()
+                .requestMatchers("/api/workspaces/**").permitAll()
                 .requestMatchers("/api/boards/**").permitAll()
                 .requestMatchers("/api/decks/**").permitAll()
                 .requestMatchers("api/cards/**").permitAll()

--- a/src/main/java/com/example/twogether/common/error/CustomErrorCode.java
+++ b/src/main/java/com/example/twogether/common/error/CustomErrorCode.java
@@ -12,27 +12,27 @@ public enum CustomErrorCode {
     PASSWORD_RECENTLY_USED("U005", "최근 2회 이내에 사용한 적 있는 비밀번호입니다."),
 
     // Workspace
-    WORKSPACE_NOT_FOUND("W001", "존재하지 않는 워크스페이스입니다."),
+    WORKSPACE_COLLABORATOR_ALREADY_EXISTS("W001", "이미 존재하는 워크스페이스 협업자입니다."),
+    WORKSPACE_NOT_FOUND("W002", "존재하지 않는 워크스페이스입니다."),
     NOT_YOUR_WORKSPACE("W003", "해당 기능은 워크스페이스를 생성한 사람만 접근 할 수 있습니다."),
+    WORKSPACE_COLLABORATOR_NOT_ACCESSIBLE("W004", "워크스페이스의 기능 사용에 실패했습니다."),
     NO_BOARDS_IN_THIS_WORKSPACE("W005", "워크스페이스에 존재하는 보드가 없습니다."),
-
-    // WorkspaceCollaborator
-    WORKSPACE_COLLABORATOR_ALREADY_EXISTS("WC001", "이미 존재하는 워크스페이스 협업자입니다."),
-    WORKSPACE_COLLABORATOR_NOT_ACCESSIBLE("WC004", "워크스페이스의 기능 사용에 실패했습니다."),
-    THIS_IS_YOUR_WORKSPACE("WC005", "당신은 워크스페이스의 관리자입니다."),
+    THIS_IS_YOUR_WORKSPACE("W006", "당신은 워크스페이스의 관리자입니다."),
+    UNINVITED_WORKSPACE("W007", "초대되지 않은 워크스페이스를 조회하였습니다."),
 
     // Board
-    BOARD_ALREADY_ARCHIVED("B001", "이미 삭제 보관된 보드입니다."),
+    BOARD_COLLABORATOR_ALREADY_EXISTS("B001", "이미 존재하는 보드 협업자입니다."),
     BOARD_NOT_FOUND("B002", "존재하지 않는 보드입니다."),
     NOT_YOUR_BOARD("B003", "해당 기능은 보드를 생성한 사람만 접근할 수 있습니다."),
     BOARD_NOT_ACCESSIBLE("B004", "보드의 CRUD 기능 사용에 실패했습니다."),
+    BOARD_COLLABORATOR_NOT_ACCESSIBLE("B005", "보드의 협업자 기능 사용에 실패했습니다."),
+    THIS_IS_YOUR_BOARD("B006", "당신은 보드의 관리자입니다."),
+    UNINVITED_BOARD("B007", "초대되지 않은 보드를 조회하였습니다."),
+    BOARD_ALREADY_ARCHIVED("B008", "이미 삭제 보관된 보드입니다."),
+    BOARD_COLLABORATOR_ALREADY_OUT("B009", "이미 추방된 보드 협업자입니다."),
+    BOARD_COLLABORATOR_NOT_FOUND("B010", "존재하지 않는 보드 협업자입니다."),
 
-    // BoardCollaborator
-    BOARD_COLLABORATOR_ALREADY_EXISTS("BC001", "이미 존재하는 보드 협업자입니다."),
-    BOARD_COLLABORATOR_NOT_FOUND("BC002", "존재하지 않는 보드 협업자입니다."),
-    BOARD_COLLABORATOR_ALREADY_OUT("B003", "이미 추방된 보드 협업자입니다."),
-    BOARD_COLLABORATOR_NOT_ACCESSIBLE("BC004", "보드의 협업자 기능 사용에 실패했습니다."),
-    THIS_IS_YOUR_BOARD("WC005", "당신은 보드의 관리자입니다."),
+
 
     // Deck
     DECK_NOT_FOUND("D001", "존재하지 않는 덱입니다."),

--- a/src/main/java/com/example/twogether/user/repository/UserRepository.java
+++ b/src/main/java/com/example/twogether/user/repository/UserRepository.java
@@ -4,9 +4,11 @@ import com.example.twogether.board.entity.Board;
 import com.example.twogether.user.entity.User;
 import com.example.twogether.workspace.entity.Workspace;
 import com.example.twogether.workspace.entity.WorkspaceCollaborator;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    List<User> findAllByEmailNot(String email);
 }

--- a/src/main/java/com/example/twogether/workspace/controller/WpColController.java
+++ b/src/main/java/com/example/twogether/workspace/controller/WpColController.java
@@ -59,8 +59,8 @@ public class WpColController {
         @PathVariable Long wpId
     ) {
 
-        WpResponseDto wpCol = wpColService.getWpCol(userDetails.getUser(), wpId);
-        return ResponseEntity.status(HttpStatus.OK).body(wpCol);
+        WpResponseDto invitedWp = wpColService.getWpCol(userDetails.getUser(), wpId);
+        return ResponseEntity.status(HttpStatus.OK).body(invitedWp);
     }
 
     @Operation(summary = "초대된 워크스페이스 전체 조회")
@@ -69,7 +69,7 @@ public class WpColController {
         @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
 
-        WpsResponseDto wpCols = wpColService.getWpCols(userDetails.getUser());
-        return ResponseEntity.status(HttpStatus.OK).body(wpCols);
+        WpsResponseDto invitedWps = wpColService.getWpCols(userDetails.getUser());
+        return ResponseEntity.status(HttpStatus.OK).body(invitedWps);
     }
 }

--- a/src/main/java/com/example/twogether/workspace/controller/WpColController.java
+++ b/src/main/java/com/example/twogether/workspace/controller/WpColController.java
@@ -3,6 +3,8 @@ package com.example.twogether.workspace.controller;
 import com.example.twogether.common.dto.ApiResponseDto;
 import com.example.twogether.common.security.UserDetailsImpl;
 import com.example.twogether.workspace.dto.WpColRequestDto;
+import com.example.twogether.workspace.dto.WpResponseDto;
+import com.example.twogether.workspace.dto.WpsResponseDto;
 import com.example.twogether.workspace.service.WpColService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -49,19 +52,24 @@ public class WpColController {
             "워크스페이스에서 협업자를 추방하였습니다."));
     }
 
-    /*
-    작성 예정
+    @Operation(summary = "초대된 워크스페이스 단건 조회")
+    @GetMapping("/workspaces/{wpId}/invite")
+    public ResponseEntity<WpResponseDto> getInvitedWp(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable Long wpId
+    ) {
+
+        WpResponseDto wpCol = wpColService.getWpCol(userDetails.getUser(), wpId);
+        return ResponseEntity.status(HttpStatus.OK).body(wpCol);
+    }
 
     @Operation(summary = "초대된 워크스페이스 전체 조회")
     @GetMapping("/workspaces/invite")
     public ResponseEntity<WpsResponseDto> getInvitedWps(
-        @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @RequestBody WpColRequestDto wpColRequestDto
+        @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
 
-        WpsResponseDto wpCols = wpColService.getWpCols(userDetails.getUser(), wpColRequestDto);
-
+        WpsResponseDto wpCols = wpColService.getWpCols(userDetails.getUser());
         return ResponseEntity.status(HttpStatus.OK).body(wpCols);
     }
-     */
 }

--- a/src/main/java/com/example/twogether/workspace/controller/WpController.java
+++ b/src/main/java/com/example/twogether/workspace/controller/WpController.java
@@ -69,12 +69,11 @@ public class WpController {
     @Operation(summary = "워크스페이스 단일 조회")
     @GetMapping("/workspaces/{id}")
     public ResponseEntity<WpResponseDto> getWorkspace(
-        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @AuthenticationPrincipal UserDetailsImpl userDetails, // 필요한지 고민
         @PathVariable Long id
     ) {
 
-        WpResponseDto wpResponseDto = wpService.getWorkspace(
-            userDetails.getUser(), id);
+        WpResponseDto wpResponseDto = wpService.getWorkspace(id);
         return ResponseEntity.ok().body(wpResponseDto);
     }
 

--- a/src/main/java/com/example/twogether/workspace/controller/WpController.java
+++ b/src/main/java/com/example/twogether/workspace/controller/WpController.java
@@ -69,7 +69,6 @@ public class WpController {
     @Operation(summary = "워크스페이스 단일 조회")
     @GetMapping("/workspaces/{id}")
     public ResponseEntity<WpResponseDto> getWorkspace(
-        @AuthenticationPrincipal UserDetailsImpl userDetails, // 필요한지 고민
         @PathVariable Long id
     ) {
 

--- a/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
@@ -3,6 +3,7 @@ package com.example.twogether.workspace.dto;
 import com.example.twogether.user.entity.User;
 import com.example.twogether.workspace.entity.Workspace;
 import com.example.twogether.workspace.entity.WorkspaceCollaborator;
+import java.util.List;
 import lombok.Getter;
 
 @Getter
@@ -10,13 +11,14 @@ public class WpColRequestDto {
 
     private Long id; // 이거 있어야 하는지 고민 중
     private String email; // 오히려 이걸 제거하는 게 더 편리할 것 같습니다.
+    private List<Workspace> workspaces;
 
-    public static WorkspaceCollaborator toEntity(User user, Workspace workspace) {
+    public static WorkspaceCollaborator toEntity(User user, List<Workspace> workspaces) {
         return WorkspaceCollaborator.builder()
             .id(user.getId())
             .email(user.getEmail())
             .user(user)
-            .workspace(workspace)
+            .workspaces(workspaces)
             .build();
     }
 }

--- a/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
@@ -21,7 +21,6 @@ public class WpColRequestDto {
         return WorkspaceCollaborator.builder()
             .id(newId)
             .email(user.getEmail())
-//            .workspaces(workspaces.stream().toList())
             .user(user)
             .workspace(workspace)
             .build();

--- a/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
@@ -13,9 +13,8 @@ public class WpColRequestDto {
 
     private Long id; // 이거 있어야 하는지 고민 중
     private String email; // 오히려 이걸 제거하는 게 더 편리할 것 같습니다.
-    private List<Workspace> workspaces;
+    private Workspace workspace;
 
-//    public static WorkspaceCollaborator toEntity(User user, List<Workspace> workspaces) {
     public static WorkspaceCollaborator toEntity(User user, Workspace workspace) {
         return WorkspaceCollaborator.builder()
             .id(user.getId())

--- a/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
@@ -5,19 +5,24 @@ import com.example.twogether.workspace.entity.Workspace;
 import com.example.twogether.workspace.entity.WorkspaceCollaborator;
 import java.util.List;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class WpColRequestDto {
 
     private Long id; // 이거 있어야 하는지 고민 중
     private String email; // 오히려 이걸 제거하는 게 더 편리할 것 같습니다.
     private List<Workspace> workspaces;
 
-    public static WorkspaceCollaborator toEntity(User user, List<Workspace> workspaces) {
+//    public static WorkspaceCollaborator toEntity(User user, List<Workspace> workspaces) {
+    public static WorkspaceCollaborator toEntity(User user, Workspace workspace) {
         return WorkspaceCollaborator.builder()
             .id(user.getId())
             .email(user.getEmail())
-            .workspaces(workspaces.stream().toList())
+//            .workspaces(workspaces.stream().toList())
+            .user(user)
+            .workspace(workspace)
             .build();
     }
 }

--- a/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
@@ -3,6 +3,7 @@ package com.example.twogether.workspace.dto;
 import com.example.twogether.user.entity.User;
 import com.example.twogether.workspace.entity.Workspace;
 import com.example.twogether.workspace.entity.WorkspaceCollaborator;
+import com.example.twogether.workspace.service.WpColService;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,13 +12,14 @@ import lombok.Setter;
 @Setter
 public class WpColRequestDto {
 
-    private Long id; // 이거 있어야 하는지 고민 중
-    private String email; // 오히려 이걸 제거하는 게 더 편리할 것 같습니다.
+    private Long id;
+    private String email;
     private Workspace workspace;
 
     public static WorkspaceCollaborator toEntity(User user, Workspace workspace) {
+        Long newId = WorkspaceCollaborator.generateUniqueId();
         return WorkspaceCollaborator.builder()
-            .id(user.getId())
+            .id(newId)
             .email(user.getEmail())
 //            .workspaces(workspaces.stream().toList())
             .user(user)

--- a/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpColRequestDto.java
@@ -17,8 +17,7 @@ public class WpColRequestDto {
         return WorkspaceCollaborator.builder()
             .id(user.getId())
             .email(user.getEmail())
-            .user(user)
-            .workspaces(workspaces)
+            .workspaces(workspaces.stream().toList())
             .build();
     }
 }

--- a/src/main/java/com/example/twogether/workspace/dto/WpColResponseDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpColResponseDto.java
@@ -1,7 +1,10 @@
 package com.example.twogether.workspace.dto;
 
 
+import com.example.twogether.user.entity.User;
+import com.example.twogether.workspace.entity.Workspace;
 import com.example.twogether.workspace.entity.WorkspaceCollaborator;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,12 +19,14 @@ public class WpColResponseDto {
     private Long wpColId;
     private String email;
     private String nickname;
+    private List<Workspace> workspaces;
 
     public static WpColResponseDto of(WorkspaceCollaborator workspaceCollaborator) {
         return WpColResponseDto.builder()
             .wpColId(workspaceCollaborator.getId())
             .email(workspaceCollaborator.getUser().getEmail())
             .nickname(workspaceCollaborator.getUser().getNickname())
+            .workspaces(workspaceCollaborator.getWorkspaces())
             .build();
     }
 }

--- a/src/main/java/com/example/twogether/workspace/dto/WpColResponseDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpColResponseDto.java
@@ -19,14 +19,14 @@ public class WpColResponseDto {
     private Long wpColId;
     private String email;
     private String nickname;
-    private List<Workspace> workspaces;
+//    private List<Workspace> workspaces;
 
     public static WpColResponseDto of(WorkspaceCollaborator workspaceCollaborator) {
         return WpColResponseDto.builder()
             .wpColId(workspaceCollaborator.getId())
             .email(workspaceCollaborator.getUser().getEmail())
             .nickname(workspaceCollaborator.getUser().getNickname())
-            .workspaces(workspaceCollaborator.getWorkspaces())
+//            .workspaces(workspaceCollaborator.getWorkspaces())
             .build();
     }
 }

--- a/src/main/java/com/example/twogether/workspace/dto/WpColResponseDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpColResponseDto.java
@@ -19,14 +19,12 @@ public class WpColResponseDto {
     private Long wpColId;
     private String email;
     private String nickname;
-//    private List<Workspace> workspaces;
 
     public static WpColResponseDto of(WorkspaceCollaborator workspaceCollaborator) {
         return WpColResponseDto.builder()
             .wpColId(workspaceCollaborator.getId())
             .email(workspaceCollaborator.getUser().getEmail())
             .nickname(workspaceCollaborator.getUser().getNickname())
-//            .workspaces(workspaceCollaborator.getWorkspaces())
             .build();
     }
 }

--- a/src/main/java/com/example/twogether/workspace/dto/WpColWpResponseDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpColWpResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.twogether.workspace.dto;
+
+import com.example.twogether.workspace.entity.WpColWp;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class WpColWpResponseDto {
+    private Long workspaceId;
+    private Long workspaceCollaboratorId;
+    private String workspaceTitle;
+
+    public static WpColWpResponseDto of(WpColWp wpColWp) {
+        return WpColWpResponseDto.builder()
+            .workspaceId(wpColWp.getWorkspace().getId())
+            .workspaceCollaboratorId(wpColWp.getWorkspaceCollaborator().getId())
+            .workspaceTitle(wpColWp.getWorkspace().getTitle())
+            .build();
+    }
+}

--- a/src/main/java/com/example/twogether/workspace/dto/WpResponseDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpResponseDto.java
@@ -22,7 +22,6 @@ public class WpResponseDto {
     private List<WpColResponseDto> wpCollaborators;
     private List<BoardResponseDto> boards;
 
-
     public static WpResponseDto of(Workspace workspace) {
         return WpResponseDto.builder()
             .workspaceId(workspace.getId())

--- a/src/main/java/com/example/twogether/workspace/dto/WpResponseDto.java
+++ b/src/main/java/com/example/twogether/workspace/dto/WpResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.twogether.workspace.dto;
 
 import com.example.twogether.board.dto.BoardResponseDto;
+import com.example.twogether.user.entity.User;
 import com.example.twogether.workspace.entity.Workspace;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -14,9 +15,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class WpResponseDto {
     private Long workspaceId;
+    private String email;
+    private String nickname;
     private String title;
     private String icon;
-    private String email;
     private List<WpColResponseDto> wpCollaborators;
     private List<BoardResponseDto> boards;
 
@@ -25,6 +27,7 @@ public class WpResponseDto {
         return WpResponseDto.builder()
             .workspaceId(workspace.getId())
             .email(workspace.getUser().getEmail())
+            .nickname(workspace.getUser().getNickname())
             .title(workspace.getTitle())
             .icon(workspace.getIcon())
             .wpCollaborators(workspace.getWorkspaceCollaborators().stream().map(WpColResponseDto::of).toList())

--- a/src/main/java/com/example/twogether/workspace/entity/Workspace.java
+++ b/src/main/java/com/example/twogether/workspace/entity/Workspace.java
@@ -26,7 +26,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "workspace")
 public class Workspace extends Timestamped {
 
     @Id

--- a/src/main/java/com/example/twogether/workspace/entity/Workspace.java
+++ b/src/main/java/com/example/twogether/workspace/entity/Workspace.java
@@ -4,7 +4,6 @@ import com.example.twogether.board.entity.Board;
 import com.example.twogether.common.entity.Timestamped;
 import com.example.twogether.user.entity.User;
 import com.example.twogether.workspace.dto.WpRequestDto;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,7 +11,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -45,7 +43,7 @@ public class Workspace extends Timestamped {
     private User user;
 
     @Builder.Default
-    @ManyToMany(mappedBy = "workspaces")
+    @OneToMany(mappedBy = "workspace", orphanRemoval = true)
     private List<WorkspaceCollaborator> workspaceCollaborators = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/com/example/twogether/workspace/entity/Workspace.java
+++ b/src/main/java/com/example/twogether/workspace/entity/Workspace.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -43,7 +44,7 @@ public class Workspace extends Timestamped {
     private User user;
 
     @Builder.Default
-    @OneToMany(mappedBy = "workspace", orphanRemoval = true)
+    @ManyToMany(mappedBy = "workspaces")
     private List<WorkspaceCollaborator> workspaceCollaborators = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/com/example/twogether/workspace/entity/Workspace.java
+++ b/src/main/java/com/example/twogether/workspace/entity/Workspace.java
@@ -4,6 +4,7 @@ import com.example.twogether.board.entity.Board;
 import com.example.twogether.common.entity.Timestamped;
 import com.example.twogether.user.entity.User;
 import com.example.twogether.workspace.dto.WpRequestDto;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/src/main/java/com/example/twogether/workspace/entity/WorkspaceCollaborator.java
+++ b/src/main/java/com/example/twogether/workspace/entity/WorkspaceCollaborator.java
@@ -1,6 +1,8 @@
 package com.example.twogether.workspace.entity;
 
 import com.example.twogether.user.entity.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -11,8 +13,10 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Builder
 @Entity
@@ -20,6 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class WorkspaceCollaborator {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,7 +35,7 @@ public class WorkspaceCollaborator {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "workspace_id")
     private Workspace workspace;
 }

--- a/src/main/java/com/example/twogether/workspace/entity/WorkspaceCollaborator.java
+++ b/src/main/java/com/example/twogether/workspace/entity/WorkspaceCollaborator.java
@@ -11,6 +11,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -21,12 +23,12 @@ import lombok.Setter;
 @Builder
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class WorkspaceCollaborator {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String email;
@@ -35,7 +37,16 @@ public class WorkspaceCollaborator {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workspace_id")
     private Workspace workspace;
+
+    // ID 수동 할당 메서드
+    public void assignNewId() {
+        this.id = generateUniqueId();
+    }
+
+    public static Long generateUniqueId() {
+        return UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;
+    }
 }

--- a/src/main/java/com/example/twogether/workspace/entity/WorkspaceCollaborator.java
+++ b/src/main/java/com/example/twogether/workspace/entity/WorkspaceCollaborator.java
@@ -1,6 +1,7 @@
 package com.example.twogether.workspace.entity;
 
 import com.example.twogether.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -37,8 +38,4 @@ public class WorkspaceCollaborator {
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "workspace_id")
     private List<Workspace> workspaces = new ArrayList<>();
-
-    public void addWorkspace(Workspace workspace) {
-        workspaces.add(workspace);
-    }
 }

--- a/src/main/java/com/example/twogether/workspace/entity/WorkspaceCollaborator.java
+++ b/src/main/java/com/example/twogether/workspace/entity/WorkspaceCollaborator.java
@@ -7,8 +7,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,7 +33,12 @@ public class WorkspaceCollaborator {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @Builder.Default
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "workspace_id")
-    private Workspace workspace;
+    private List<Workspace> workspaces = new ArrayList<>();
+
+    public void addWorkspace(Workspace workspace) {
+        workspaces.add(workspace);
+    }
 }

--- a/src/main/java/com/example/twogether/workspace/entity/WorkspaceCollaborator.java
+++ b/src/main/java/com/example/twogether/workspace/entity/WorkspaceCollaborator.java
@@ -1,18 +1,14 @@
 package com.example.twogether.workspace.entity;
 
 import com.example.twogether.user.entity.User;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,8 +30,7 @@ public class WorkspaceCollaborator {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Builder.Default
-    @ManyToMany(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workspace_id")
-    private List<Workspace> workspaces = new ArrayList<>();
+    private Workspace workspace;
 }

--- a/src/main/java/com/example/twogether/workspace/entity/WpColWp.java
+++ b/src/main/java/com/example/twogether/workspace/entity/WpColWp.java
@@ -1,0 +1,76 @@
+package com.example.twogether.workspace.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.io.Serializable;
+import java.time.LocalDate;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+// 중간 테이블
+@Getter
+//@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class WpColWp implements Persistable<WpColWpId> {
+    // 복합키 매핑
+    @EmbeddedId
+    private WpColWpId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "workspace_id", insertable=false, updatable=false)
+    private Workspace workspace;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "workspace_collaborator_id", insertable=false, updatable=false)
+    private WorkspaceCollaborator workspaceCollaborator;
+
+    @CreatedDate
+    private LocalDate created;
+
+    public void setParent(Workspace workspace) {
+        this.workspace = workspace;
+        this.id = new WpColWpId(workspace.getId(), workspaceCollaborator.getId());
+    }
+
+    @Override
+    public WpColWpId getId() {
+        return id;
+    }
+
+    // Spring Data JPA 에서는 데이터를 저장하는 save()는
+    // 새로운 엔티티라고 판단되면 persist()를 실행하고, 그렇지 않다면 merge()를 호출한다.
+    // merge()를 방지하기 위해 새로운 엔티티인지 판별하는 방법으로 created time 을 사용했다.
+    @Override
+    public boolean isNew() {
+        return created == null;
+    }
+}
+
+// 식별자 클래스
+@Embeddable
+@NoArgsConstructor
+@EqualsAndHashCode
+class WpColWpId implements Serializable {
+    @Column(name = "workspace_id")
+    private Long wpId;
+
+    @Column(name = "workspace_collaborator_id")
+    private Long wpColId;
+
+    public WpColWpId(Long wpId, Long wpColId) {
+        this.wpId = wpId;
+        this.wpColId = wpColId;
+    }
+}

--- a/src/main/java/com/example/twogether/workspace/entity/WpColWp.java
+++ b/src/main/java/com/example/twogether/workspace/entity/WpColWp.java
@@ -39,21 +39,11 @@ public class WpColWp implements Persistable<WpColWpId> {
     @CreatedDate
     private LocalDate created;
 
-    // 부모 엔티티와 연관된 정보를 설정 - 필요한지 고민 중
-    // (생성된 WpColWp 엔티티가 어떤 워크스페이스와 협업자 간의 관계를 가지는지 설정)
-    public void setParent(Workspace workspace) {
-        this.workspace = workspace;
-        this.id = new WpColWpId(workspace.getId(), workspaceCollaborator.getId());
-    }
-
     @Override
     public WpColWpId getId() {
         return id;
     }
 
-    // Spring Data JPA 에서는 데이터를 저장하는 save()는
-    // 새로운 엔티티라고 판단되면 persist()를 실행하고, 그렇지 않다면 merge()를 호출한다.
-    // merge()를 방지하기 위해 새로운 엔티티인지 판별하는 방법으로 created time 을 사용했다.
     @Override
     public boolean isNew() {
         return created == null;

--- a/src/main/java/com/example/twogether/workspace/entity/WpColWp.java
+++ b/src/main/java/com/example/twogether/workspace/entity/WpColWp.java
@@ -39,6 +39,8 @@ public class WpColWp implements Persistable<WpColWpId> {
     @CreatedDate
     private LocalDate created;
 
+    // 부모 엔티티와 연관된 정보를 설정 - 필요한지 고민 중
+    // (생성된 WpColWp 엔티티가 어떤 워크스페이스와 협업자 간의 관계를 가지는지 설정)
     public void setParent(Workspace workspace) {
         this.workspace = workspace;
         this.id = new WpColWpId(workspace.getId(), workspaceCollaborator.getId());

--- a/src/main/java/com/example/twogether/workspace/entity/WpColWp.java
+++ b/src/main/java/com/example/twogether/workspace/entity/WpColWp.java
@@ -57,20 +57,3 @@ public class WpColWp implements Persistable<WpColWpId> {
         return created == null;
     }
 }
-
-// 식별자 클래스
-@Embeddable
-@NoArgsConstructor
-@EqualsAndHashCode
-class WpColWpId implements Serializable {
-    @Column(name = "workspace_id")
-    private Long wpId;
-
-    @Column(name = "workspace_collaborator_id")
-    private Long wpColId;
-
-    public WpColWpId(Long wpId, Long wpColId) {
-        this.wpId = wpId;
-        this.wpColId = wpColId;
-    }
-}

--- a/src/main/java/com/example/twogether/workspace/entity/WpColWpId.java
+++ b/src/main/java/com/example/twogether/workspace/entity/WpColWpId.java
@@ -1,0 +1,25 @@
+package com.example.twogether.workspace.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+// 식별자 클래스
+@Embeddable
+@NoArgsConstructor
+@EqualsAndHashCode
+public class WpColWpId implements Serializable {
+    @Column(name = "workspace_id")
+    private Long wpId;
+
+    @Column(name = "workspace_collaborator_id")
+    private Long wpColId;
+
+    public WpColWpId(Long wpId, Long wpColId) {
+        this.wpId = wpId;
+        this.wpColId = wpColId;
+    }
+}
+

--- a/src/main/java/com/example/twogether/workspace/entity/WpColWpId.java
+++ b/src/main/java/com/example/twogether/workspace/entity/WpColWpId.java
@@ -3,10 +3,12 @@ package com.example.twogether.workspace.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 // 식별자 클래스
+@Builder
 @Embeddable
 @NoArgsConstructor
 @EqualsAndHashCode

--- a/src/main/java/com/example/twogether/workspace/repository/WpColRepository.java
+++ b/src/main/java/com/example/twogether/workspace/repository/WpColRepository.java
@@ -11,6 +11,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface WpColRepository extends JpaRepository<WorkspaceCollaborator, Long> {
     boolean existsByWorkspacesAndEmail(Workspace workspace, String email);
     Optional<WorkspaceCollaborator> findByWorkspacesAndEmail(Workspace workspace, String email);
-    List<WorkspaceCollaborator> findAllByEmail(String email);
-    WorkspaceCollaborator findByUser(User user);
 }

--- a/src/main/java/com/example/twogether/workspace/repository/WpColRepository.java
+++ b/src/main/java/com/example/twogether/workspace/repository/WpColRepository.java
@@ -11,4 +11,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface WpColRepository extends JpaRepository<WorkspaceCollaborator, Long> {
     boolean existsByWorkspaceAndEmail(Workspace workspace, String email);
     Optional<WorkspaceCollaborator> findByWorkspaceAndEmail(Workspace workspace, String email);
+
+    List<WorkspaceCollaborator> findByUser(User user);
 }

--- a/src/main/java/com/example/twogether/workspace/repository/WpColRepository.java
+++ b/src/main/java/com/example/twogether/workspace/repository/WpColRepository.java
@@ -9,6 +9,6 @@ import org.hibernate.jdbc.Work;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WpColRepository extends JpaRepository<WorkspaceCollaborator, Long> {
-    boolean existsByWorkspacesAndEmail(Workspace workspace, String email);
-    Optional<WorkspaceCollaborator> findByWorkspacesAndEmail(Workspace workspace, String email);
+    boolean existsByWorkspaceAndEmail(Workspace workspace, String email);
+    Optional<WorkspaceCollaborator> findByWorkspaceAndEmail(Workspace workspace, String email);
 }

--- a/src/main/java/com/example/twogether/workspace/repository/WpColRepository.java
+++ b/src/main/java/com/example/twogether/workspace/repository/WpColRepository.java
@@ -9,6 +9,8 @@ import org.hibernate.jdbc.Work;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WpColRepository extends JpaRepository<WorkspaceCollaborator, Long> {
-    boolean existsByWorkspaceAndEmail(Workspace workspace, String email);
-    Optional<WorkspaceCollaborator> findByWorkspaceAndEmail(Workspace workspace, String email);
+    boolean existsByWorkspacesAndEmail(Workspace workspace, String email);
+    Optional<WorkspaceCollaborator> findByWorkspacesAndEmail(Workspace workspace, String email);
+    List<WorkspaceCollaborator> findAllByEmail(String email);
+    WorkspaceCollaborator findByUser(User user);
 }

--- a/src/main/java/com/example/twogether/workspace/repository/WpColWpRepository.java
+++ b/src/main/java/com/example/twogether/workspace/repository/WpColWpRepository.java
@@ -1,0 +1,8 @@
+package com.example.twogether.workspace.repository;
+
+import com.example.twogether.workspace.entity.WpColWp;
+import com.example.twogether.workspace.entity.WpColWpId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WpColWpRepository extends JpaRepository<WpColWp, WpColWpId> {
+}

--- a/src/main/java/com/example/twogether/workspace/repository/WpColWpRepository.java
+++ b/src/main/java/com/example/twogether/workspace/repository/WpColWpRepository.java
@@ -1,8 +1,11 @@
 package com.example.twogether.workspace.repository;
 
+import com.example.twogether.workspace.entity.WorkspaceCollaborator;
 import com.example.twogether.workspace.entity.WpColWp;
 import com.example.twogether.workspace.entity.WpColWpId;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WpColWpRepository extends JpaRepository<WpColWp, WpColWpId> {
+    Optional<WorkspaceCollaborator> findByWorkspace_IdAndWorkspaceCollaborator_Email(Long wpId, String email);
 }

--- a/src/main/java/com/example/twogether/workspace/repository/WpRepository.java
+++ b/src/main/java/com/example/twogether/workspace/repository/WpRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WpRepository extends JpaRepository<Workspace, Long> {
     List<Workspace> findAllByUserOrderByCreatedAtDesc(User user);
-    Optional<Workspace> findByWorkspaceCollaborators_Email(String email);
     List<Workspace> findAllByWorkspaceCollaborators_Email(String email);
+    Optional<Workspace> findByIdAndWorkspaceCollaborators_Email(Long wpId, String email);
 }

--- a/src/main/java/com/example/twogether/workspace/repository/WpRepository.java
+++ b/src/main/java/com/example/twogether/workspace/repository/WpRepository.java
@@ -9,4 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface WpRepository extends JpaRepository<Workspace, Long> {
     List<Workspace> findAllByUserOrderByCreatedAtDesc(User user);
     Optional<Workspace> findByWorkspaceCollaborators_Email(String email);
+    List<Workspace> findAllByWorkspaceCollaborators_Email(String email);
 }

--- a/src/main/java/com/example/twogether/workspace/repository/WpRepository.java
+++ b/src/main/java/com/example/twogether/workspace/repository/WpRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WpRepository extends JpaRepository<Workspace, Long> {
     List<Workspace> findAllByUserOrderByCreatedAtDesc(User user);
+    List<Workspace> findAllByWorkspaceCollaborators_User(User user);
+    Optional<Workspace> findByWorkspaceCollaborators_Email(String email);
 }

--- a/src/main/java/com/example/twogether/workspace/repository/WpRepository.java
+++ b/src/main/java/com/example/twogether/workspace/repository/WpRepository.java
@@ -1,5 +1,6 @@
 package com.example.twogether.workspace.repository;
 
+import com.example.twogether.board.entity.Board;
 import com.example.twogether.user.entity.User;
 import com.example.twogether.workspace.entity.Workspace;
 import java.util.List;

--- a/src/main/java/com/example/twogether/workspace/repository/WpRepository.java
+++ b/src/main/java/com/example/twogether/workspace/repository/WpRepository.java
@@ -8,6 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WpRepository extends JpaRepository<Workspace, Long> {
     List<Workspace> findAllByUserOrderByCreatedAtDesc(User user);
-    List<Workspace> findAllByWorkspaceCollaborators_User(User user);
     Optional<Workspace> findByWorkspaceCollaborators_Email(String email);
 }

--- a/src/main/java/com/example/twogether/workspace/service/WpColService.java
+++ b/src/main/java/com/example/twogether/workspace/service/WpColService.java
@@ -92,8 +92,8 @@ public class WpColService {
         Workspace foundWorkspace = findWpById(wpId);
 
         // 워크스페이스를 생성한 사람만 협업자 추방하기 가능
-        if (!foundWorkspace.getUser().getId().equals(user.getId()) && !user.getRole()
-            .equals(UserRoleEnum.ADMIN)) {
+        if (!foundWorkspace.getUser().getId().equals(user.getId()) &&
+            !user.getRole().equals(UserRoleEnum.ADMIN)) {
             throw new CustomException(CustomErrorCode.NOT_YOUR_WORKSPACE);
         }
 

--- a/src/main/java/com/example/twogether/workspace/service/WpColService.java
+++ b/src/main/java/com/example/twogether/workspace/service/WpColService.java
@@ -11,10 +11,15 @@ import com.example.twogether.user.entity.User;
 import com.example.twogether.user.entity.UserRoleEnum;
 import com.example.twogether.user.repository.UserRepository;
 import com.example.twogether.workspace.dto.WpColRequestDto;
+import com.example.twogether.workspace.dto.WpColResponseDto;
+import com.example.twogether.workspace.dto.WpResponseDto;
+import com.example.twogether.workspace.dto.WpsResponseDto;
 import com.example.twogether.workspace.entity.Workspace;
 import com.example.twogether.workspace.entity.WorkspaceCollaborator;
 import com.example.twogether.workspace.repository.WpColRepository;
 import com.example.twogether.workspace.repository.WpRepository;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,10 +41,11 @@ public class WpColService {
     @Transactional
     public void inviteWpCol(User user, Long wpId, String email) {
 
-        Workspace foundWorkspace = findWorkspace(wpId); // 중복되는 코드 처리 고민 중
+        List<Workspace> foundWorkspaces = findAllWpById(wpId); // 중복되는 코드 처리 고민 중
 
         // 워크스페이스를 생성한 사람만 협업자 초대 가능
-        if (!foundWorkspace.getUser().getId().equals(user.getId()) && !user.getRole().equals(UserRoleEnum.ADMIN)) {
+        if (!foundWorkspaces.get(0).getUser().getId().equals(user.getId()) &&
+            !user.getRole().equals(UserRoleEnum.ADMIN)) {
             throw new CustomException(CustomErrorCode.NOT_YOUR_WORKSPACE);
         }
 
@@ -49,31 +55,36 @@ public class WpColService {
         }
 
         // 이미 등록된 사용자 초대당하기 불가
-        if (wpColRepository.existsByWorkspaceAndEmail(foundWorkspace, email)) {
-            throw new CustomException(CustomErrorCode.WORKSPACE_COLLABORATOR_ALREADY_EXISTS);
+        for(int i=0; i< foundWorkspaces.size(); i++) {
+            if (wpColRepository.existsByWorkspacesAndEmail(foundWorkspaces.get(i), email)) {
+                throw new CustomException(CustomErrorCode.WORKSPACE_COLLABORATOR_ALREADY_EXISTS);
+            }
         }
 
         // 워크스페이스 협업자로 등록
         User foundUser = findUser(email);
-        WorkspaceCollaborator foundWpCol = WpColRequestDto.toEntity(foundUser, foundWorkspace);
+        WorkspaceCollaborator foundWpCol = WpColRequestDto.toEntity(foundUser, foundWorkspaces);
         wpColRepository.save(foundWpCol);
 
-        // 워크스페이스에서 초대한 협업자 모든 하위 보드도 자동 초대
-        List<Board> foundAllBoards = findAllBoards(foundWorkspace);
-        if (foundAllBoards != null && !foundAllBoards.isEmpty()) {
+        for(Workspace foundWorkspace : foundWorkspaces) {
+            foundWpCol.addWorkspace(foundWorkspace);
+            // 워크스페이스에서 초대한 협업자 모든 하위 보드도 자동 초대
+            List<Board> foundAllBoards = findAllBoards(foundWorkspace);
+            if (foundAllBoards != null && !foundAllBoards.isEmpty()) {
 
-            for (Board foundBoard : foundAllBoards) {
+                for (Board foundBoard : foundAllBoards) {
 
-                // 해당 보드에 이미 등록된 협업자인 경우 예외 던지기
-                if (boardColRepository.existsByBoardAndEmail(foundBoard,
-                    foundUser.getEmail())) {
-                    log.error("워크스페이스에 포함된 보드 중 이미 협업자가 등록된 경우가 있습니다.");
-                    continue;
+                    // 해당 보드에 이미 등록된 협업자인 경우 예외 던지기
+                    if (boardColRepository.existsByBoardAndEmail(foundBoard,
+                        foundUser.getEmail())) {
+                        log.error("워크스페이스에 포함된 보드 중 이미 협업자가 등록된 경우가 있습니다.");
+                        continue;
+                    }
+
+                    BoardCollaborator boardCollaborator = BoardColRequestDto.toEntity(foundUser,
+                        foundBoard);
+                    boardColRepository.save(boardCollaborator); // 수정된 사항 확인에 대해 포스트맨 테스트 필요
                 }
-
-                BoardCollaborator boardCollaborator = BoardColRequestDto.toEntity(foundUser,
-                    foundBoard);
-                boardColRepository.save(boardCollaborator); // 수정된 사항 확인에 대해 포스트맨 테스트 필요
             }
         }
     }
@@ -82,7 +93,7 @@ public class WpColService {
     @Transactional
     public void outWpCol(User user, Long wpId, String email) {
 
-        Workspace foundWorkspace = findWorkspace(wpId);
+        Workspace foundWorkspace = findWpById(wpId);
 
         // 워크스페이스를 생성한 사람만 협업자 추방하기 가능
         if (!foundWorkspace.getUser().getId().equals(user.getId()) && !user.getRole().equals(UserRoleEnum.ADMIN)) {
@@ -96,7 +107,7 @@ public class WpColService {
 
         // 워크스페이스 협업자 삭제
         User foundUser = findUser(email);
-        WorkspaceCollaborator foundWpCol = findWpCol(foundWorkspace, email);
+        WorkspaceCollaborator foundWpCol = findWpColByEmail(foundWorkspace, email);
         wpColRepository.delete(foundWpCol);
 
         // 워크스페이스에서 추방한 협업자 모든 하위 보드에서 자동 추방
@@ -118,25 +129,74 @@ public class WpColService {
         }
     }
 
-    /*
+    // 초대된 워크스페이스 단건 조회
     @Transactional(readOnly = true)
-    public WpsResponseDto getWpCols(User user, WpColRequestDto wpColRequestDto) {
+    public WpResponseDto getWpCol(User user, Long wpId) {
 
-        List<WorkspaceCollaborator> wpCols = wpColRepository.findAllById(Collections.singleton(wpColRequestDto.getId()));
-        List<Workspace> foundWorkspaces = new ArrayList<>();
-        for(WorkspaceCollaborator workspaceCollaborator : wpCols) {
-            Workspace foundWorkspace = findWorkspace(workspaceCollaborator.getId());
-            foundWorkspaces.add(foundWorkspace);
+        Workspace foundWorkspace = findWpByEmail(user);
+
+        if(wpId != foundWorkspace.getId()) {
+            throw new CustomException(CustomErrorCode.UNINVITED_WORKSPACE);
         }
 
-        return WpsResponseDto.of(foundWorkspaces);
+        return WpResponseDto.of(foundWorkspace);
     }
-     */
 
-    private Workspace findWorkspace(Long wpId) {
+    // 초대된 워크스페이스 전체 조회
+    @Transactional(readOnly = true)
+    public WpsResponseDto getWpCols(User user) {
+
+        List<Workspace> AllWps = findAllWps();
+        List<Workspace> invitedWps = new ArrayList<>(); // findAllWpsByUser(user);
+
+        // WorkspaceCollaborator 가 user 인 모든 workspace 를 조회
+        for(Workspace invitedWp : AllWps) {
+            for (WorkspaceCollaborator collaborator : invitedWp.getWorkspaceCollaborators()) {
+                if (collaborator.getUser().getEmail().equals(user.getEmail())) {
+                    invitedWps.add(invitedWp);
+                    break;
+                }
+            }
+        }
+
+        // 초대된 워크스페이스에 포함되어 있는 보드 중, boardCollaborator 로 되어 있는 보드만 조회
+        List<Workspace> filteredWorkspaces = new ArrayList<>();
+        for (Workspace workspace : invitedWps) {
+            boolean allBoardsInvited = true;
+            for (Board board : workspace.getBoards()) {
+                if (!boardColRepository.existsByBoardAndEmail(board, user.getEmail())) {
+                    allBoardsInvited = false;
+                    break;
+                }
+            }
+            if (allBoardsInvited) {
+                filteredWorkspaces.add(workspace);
+            }
+        }
+
+        return WpsResponseDto.of(filteredWorkspaces);
+    }
+
+    private Workspace findWpById(Long wpId) {
 
         return wpRepository.findById(wpId).orElseThrow(() ->
             new CustomException(CustomErrorCode.WORKSPACE_NOT_FOUND));
+    }
+
+    private List<Workspace> findAllWpById(Long wpId) {
+
+        return wpRepository.findAllById(Collections.singleton(wpId));
+    }
+
+
+    private Workspace findWpByEmail(User user) {
+
+        return wpRepository.findByWorkspaceCollaborators_Email(user.getEmail()).orElseThrow(() ->
+            new CustomException(CustomErrorCode.WORKSPACE_NOT_FOUND));
+    }
+
+    private List<Workspace> findAllWps() {
+        return wpRepository.findAll();
     }
 
     private User findUser(String email) {
@@ -150,9 +210,9 @@ public class WpColService {
             new CustomException(CustomErrorCode.BOARD_NOT_FOUND));
     }
 
-    private WorkspaceCollaborator findWpCol(Workspace foundWorkspace, String email) {
+    private WorkspaceCollaborator findWpColByEmail(Workspace foundWorkspace, String email) {
 
-        return wpColRepository.findByWorkspaceAndEmail(foundWorkspace, email).orElseThrow(() ->
+        return wpColRepository.findByWorkspacesAndEmail(foundWorkspace, email).orElseThrow(() ->
             new CustomException(CustomErrorCode.USER_NOT_FOUND));
     }
 

--- a/src/main/java/com/example/twogether/workspace/service/WpColService.java
+++ b/src/main/java/com/example/twogether/workspace/service/WpColService.java
@@ -15,14 +15,20 @@ import com.example.twogether.workspace.dto.WpResponseDto;
 import com.example.twogether.workspace.dto.WpsResponseDto;
 import com.example.twogether.workspace.entity.Workspace;
 import com.example.twogether.workspace.entity.WorkspaceCollaborator;
+import com.example.twogether.workspace.entity.WpColWp;
+import com.example.twogether.workspace.entity.WpColWpId;
 import com.example.twogether.workspace.repository.WpColRepository;
+import com.example.twogether.workspace.repository.WpColWpRepository;
 import com.example.twogether.workspace.repository.WpRepository;
+import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.SerializationUtils;
+import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +39,7 @@ public class WpColService {
 
     private final WpColRepository wpColRepository;
     private final WpRepository wpRepository;
+    private final WpColWpRepository wpColWpRepository;
     private final BoardColRepository boardColRepository;
     private final BoardRepository boardRepository;
     private final UserRepository userRepository;
@@ -59,40 +66,27 @@ public class WpColService {
             throw new CustomException(CustomErrorCode.WORKSPACE_COLLABORATOR_ALREADY_EXISTS);
         }
 
-//        for (Workspace workspace : foundWorkspaces) {
-//            if (wpColRepository.existsByWorkspaceAndEmail(workspace, email)) {
-//                throw new CustomException(CustomErrorCode.WORKSPACE_COLLABORATOR_ALREADY_EXISTS);
-//            }
-//        }
-
         // 워크스페이스 협업자로 등록
         User foundUser = findUser(email);
         WorkspaceCollaborator newWpCol = WpColRequestDto.toEntity(foundUser, foundWorkspace);
+        newWpCol.assignNewId();
+
         foundWorkspace.getWorkspaceCollaborators().add(newWpCol);
-//        WorkspaceCollaborator foundWpCol = WpColRequestDto.toEntity(foundUser, foundWorkspaces);
         wpColRepository.save(newWpCol);
 
-//        for(Workspace foundWorkspace : foundWorkspaces) {
-//            try {
-//                foundWpCol.getWorkspaces().add(foundWorkspace);
-//            } catch (Exception ex) {
-//                log.error("Error while adding workspace to collaborator: " + ex.getMessage());
-//            }
+        // 워크스페이스에서 초대한 협업자 모든 하위 보드도 자동 초대
+        List<Board> foundAllBoards = findAllBoards(foundWorkspace);
+        if (foundAllBoards != null && !foundAllBoards.isEmpty()) {
 
-            // 워크스페이스에서 초대한 협업자 모든 하위 보드도 자동 초대
-            List<Board> foundAllBoards = findAllBoards(foundWorkspace);
-            if (foundAllBoards != null && !foundAllBoards.isEmpty()) {
+            for (Board foundBoard : foundAllBoards) {
 
-                for (Board foundBoard : foundAllBoards) {
-
-                    // 해당 보드에 이미 등록된 협업자인 경우 예외 던지기
-                    if (!boardColRepository.existsByBoardAndEmail(foundBoard, foundUser.getEmail())) {
-                        BoardCollaborator boardCollaborator = BoardColRequestDto.toEntity(foundUser, foundBoard);
-                        boardColRepository.save(boardCollaborator); // 수정된 사항 확인에 대해 포스트맨 테스트 필요
-                    }
+                // 해당 보드에 이미 등록된 협업자인 경우 예외 던지기
+                if (!boardColRepository.existsByBoardAndEmail(foundBoard, foundUser.getEmail())) {
+                    BoardCollaborator boardCollaborator = BoardColRequestDto.toEntity(foundUser, foundBoard);
+                    boardColRepository.save(boardCollaborator); // 수정된 사항 확인에 대해 포스트맨 테스트 필요
                 }
             }
-//        }
+        }
     }
 
     // 워크스페이스 협업자 추방
@@ -102,7 +96,8 @@ public class WpColService {
         Workspace foundWorkspace = findWpById(wpId);
 
         // 워크스페이스를 생성한 사람만 협업자 추방하기 가능
-        if (!foundWorkspace.getUser().getId().equals(user.getId()) && !user.getRole().equals(UserRoleEnum.ADMIN)) {
+        if (!foundWorkspace.getUser().getId().equals(user.getId()) && !user.getRole()
+            .equals(UserRoleEnum.ADMIN)) {
             throw new CustomException(CustomErrorCode.NOT_YOUR_WORKSPACE);
         }
 
@@ -140,11 +135,9 @@ public class WpColService {
     public WpResponseDto getWpCol(User user, Long wpId) {
 
         Workspace foundWorkspace = findWpByEmail(user);
-
-        if(!Objects.equals(wpId, foundWorkspace.getId())) {
+        if (!Objects.equals(wpId, foundWorkspace.getId())) {
             throw new CustomException(CustomErrorCode.UNINVITED_WORKSPACE);
         }
-
         return WpResponseDto.of(foundWorkspace);
     }
 
@@ -152,32 +145,24 @@ public class WpColService {
     @Transactional(readOnly = true)
     public WpsResponseDto getWpCols(User user) {
 
-        List<Workspace> AllWps = findAllWps();
-        List<Workspace> invitedWps = new ArrayList<>(); // findAllWpsByUser(user);
-
-        // WorkspaceCollaborator 가 user 인 모든 workspace 를 조회
-        for(Workspace invitedWp : AllWps) {
-            for (WorkspaceCollaborator collaborator : invitedWp.getWorkspaceCollaborators()) {
-                if (collaborator.getUser().getEmail().equals(user.getEmail())) {
-                    invitedWps.add(invitedWp);
-                    break;
-                }
-            }
-        }
-
-        // 초대된 워크스페이스에 포함되어 있는 보드 중, boardCollaborator 로 되어 있는 보드만 조회
+        List<Workspace> foundWorkspaces = findAllWpsByEmail(user.getEmail());
         List<Workspace> filteredWorkspaces = new ArrayList<>();
-        for (Workspace workspace : invitedWps) {
-            boolean allBoardsInvited = true;
+        boolean allBoardsInvited = true;
+        for (Workspace workspace : foundWorkspaces) {
+
+            // 해당 협업자와 워크스페이스가 연결된 WpColWp를 조회
+            WpColWpId wpColWpId = new WpColWpId(workspace.getId(), user.getId());
+            Optional<WpColWp> wpColWpOptional = wpColWpRepository.findById(wpColWpId);
+
+            if (wpColWpOptional.isPresent()) filteredWorkspaces.add(workspace);
+
+            // 초대된 워크스페이스에 포함되어 있는 보드 중, boardCollaborator 로 되어 있는 보드만 조회
             for (Board board : workspace.getBoards()) {
                 if (!boardColRepository.existsByBoardAndEmail(board, user.getEmail())) {
-                    allBoardsInvited = false;
-                    break;
+                    allBoardsInvited = false; break;
                 }
             }
-            if (allBoardsInvited) {
-                filteredWorkspaces.add(workspace);
-            }
+            if (allBoardsInvited) filteredWorkspaces.add(workspace);
         }
 
         return WpsResponseDto.of(filteredWorkspaces);
@@ -203,6 +188,10 @@ public class WpColService {
 
     private List<Workspace> findAllWps() {
         return wpRepository.findAll();
+    }
+
+    private List<Workspace> findAllWpsByEmail(String email) {
+        return wpRepository.findAllByWorkspaceCollaborators_Email(email);
     }
 
     private User findUser(String email) {

--- a/src/main/java/com/example/twogether/workspace/service/WpColService.java
+++ b/src/main/java/com/example/twogether/workspace/service/WpColService.java
@@ -139,7 +139,7 @@ public class WpColService {
         return WpResponseDto.of(foundWorkspace);
     }
 
-    // 초대된 워크스페이스 전체 조회 - 리팩토링 필요
+    // 초대된 워크스페이스 전체 조회
     @Transactional(readOnly = true)
     public WpsResponseDto getWpCols(User user) {
 

--- a/src/main/java/com/example/twogether/workspace/service/WpColService.java
+++ b/src/main/java/com/example/twogether/workspace/service/WpColService.java
@@ -15,15 +15,10 @@ import com.example.twogether.workspace.dto.WpResponseDto;
 import com.example.twogether.workspace.dto.WpsResponseDto;
 import com.example.twogether.workspace.entity.Workspace;
 import com.example.twogether.workspace.entity.WorkspaceCollaborator;
-import com.example.twogether.workspace.entity.WpColWp;
-import com.example.twogether.workspace.entity.WpColWpId;
 import com.example.twogether.workspace.repository.WpColRepository;
 import com.example.twogether.workspace.repository.WpColWpRepository;
 import com.example.twogether.workspace.repository.WpRepository;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,7 +31,6 @@ public class WpColService {
 
     private final WpColRepository wpColRepository;
     private final WpRepository wpRepository;
-    private final WpColWpRepository wpColWpRepository;
     private final BoardColRepository boardColRepository;
     private final BoardRepository boardRepository;
     private final UserRepository userRepository;
@@ -132,8 +126,7 @@ public class WpColService {
             throw new CustomException(CustomErrorCode.NOT_YOUR_WORKSPACE);
         }
 
-        // 워크스페이스 오너는 추방당하기 불가 - 해당 사항에 대해 추후 프론트에서 예외처리되면 삭제될 예정
-        if (email.equals(user.getEmail())) {
+        if (email.equals(user.getEmail())) { // 추후 프론트에서 예외처리되면 삭제될 예정
             
             log.error("워크스페이스의 오너는 초대/추방할 수 없습니다.");
             throw new CustomException(CustomErrorCode.THIS_IS_YOUR_WORKSPACE);

--- a/src/main/java/com/example/twogether/workspace/service/WpColService.java
+++ b/src/main/java/com/example/twogether/workspace/service/WpColService.java
@@ -67,9 +67,10 @@ public class WpColService {
 
         // 워크스페이스 협업자로 등록
         User foundUser = findUser(email);
-        WorkspaceCollaborator foundWpCol = WpColRequestDto.toEntity(foundUser, foundWorkspace);
+        WorkspaceCollaborator newWpCol = WpColRequestDto.toEntity(foundUser, foundWorkspace);
+        foundWorkspace.getWorkspaceCollaborators().add(newWpCol);
 //        WorkspaceCollaborator foundWpCol = WpColRequestDto.toEntity(foundUser, foundWorkspaces);
-        wpColRepository.save(foundWpCol);
+        wpColRepository.save(newWpCol);
 
 //        for(Workspace foundWorkspace : foundWorkspaces) {
 //            try {
@@ -85,15 +86,10 @@ public class WpColService {
                 for (Board foundBoard : foundAllBoards) {
 
                     // 해당 보드에 이미 등록된 협업자인 경우 예외 던지기
-                    if (boardColRepository.existsByBoardAndEmail(foundBoard,
-                        foundUser.getEmail())) {
-                        log.error("워크스페이스에 포함된 보드 중 이미 협업자가 등록된 경우가 있습니다.");
-                        continue;
+                    if (!boardColRepository.existsByBoardAndEmail(foundBoard, foundUser.getEmail())) {
+                        BoardCollaborator boardCollaborator = BoardColRequestDto.toEntity(foundUser, foundBoard);
+                        boardColRepository.save(boardCollaborator); // 수정된 사항 확인에 대해 포스트맨 테스트 필요
                     }
-
-                    BoardCollaborator boardCollaborator = BoardColRequestDto.toEntity(foundUser,
-                        foundBoard);
-                    boardColRepository.save(boardCollaborator); // 수정된 사항 확인에 대해 포스트맨 테스트 필요
                 }
             }
 //        }

--- a/src/main/java/com/example/twogether/workspace/service/WpColService.java
+++ b/src/main/java/com/example/twogether/workspace/service/WpColService.java
@@ -94,16 +94,20 @@ public class WpColService {
         // 워크스페이스를 생성한 사람만 협업자 추방하기 가능
         if (!foundWorkspace.getUser().getId().equals(user.getId()) &&
             !user.getRole().equals(UserRoleEnum.ADMIN)) {
+
+            log.error("워크스페이스를 생성한 사람만 협업자 추방할 수 있습니다.");
             throw new CustomException(CustomErrorCode.NOT_YOUR_WORKSPACE);
         }
 
         // 워크스페이스 오너는 추방당하기 불가 - 해당 사항에 대해 추후 프론트에서 예외처리되면 삭제될 예정
         if (email.equals(user.getEmail())) {
+            log.error("워크스페이스의 오너는 초대할 수 없습니다.");
             throw new CustomException(CustomErrorCode.THIS_IS_YOUR_WORKSPACE);
         }
 
-        // 워크스페이스 협업자 삭제
         User foundUser = findUser(email);
+
+        // 워크스페이스 협업자 삭제
         WorkspaceCollaborator foundWpCol = findWpColByEmail(foundWorkspace, email);
         wpColRepository.delete(foundWpCol);
 

--- a/src/main/java/com/example/twogether/workspace/service/WpService.java
+++ b/src/main/java/com/example/twogether/workspace/service/WpService.java
@@ -24,28 +24,28 @@ public class WpService {
     private final WpRepository wpRepository;
 
     @Transactional
-    public WpResponseDto createWorkspace(User wpAuthor, WpRequestDto wpRequestDto){
+    public WpResponseDto createWorkspace(User user, WpRequestDto wpRequestDto){
 
-        Workspace foundWp = wpRequestDto.toEntity(wpAuthor);
+        Workspace foundWp = wpRequestDto.toEntity(user);
         wpRepository.save(foundWp);
         return WpResponseDto.of(foundWp);
     }
 
     @Transactional
-    public WpResponseDto editWorkspace(User wpAuthor, Long id, WpRequestDto wpRequestDto) {
+    public WpResponseDto editWorkspace(User user, Long id, WpRequestDto wpRequestDto) {
 
         Workspace workspace = findWorkspace(id);
-        if(workspace.getUser().getId().equals(wpAuthor.getId())||wpAuthor.getRole().equals(UserRoleEnum.ADMIN)) {
+        if(workspace.getUser().getId().equals(user.getId())||user.getRole().equals(UserRoleEnum.ADMIN)) {
             workspace.update(wpRequestDto);
             return WpResponseDto.of(workspace);
         } else throw new CustomException(CustomErrorCode.NOT_YOUR_WORKSPACE);
     }
 
     @Transactional
-    public void deleteWorkspace(User wpAuthor, Long id) {
+    public void deleteWorkspace(User user, Long id) {
 
         Workspace workspace = findWorkspace(id);
-        if(workspace.getUser().getId().equals(wpAuthor.getId())||wpAuthor.getRole().equals(UserRoleEnum.ADMIN)) {
+        if(workspace.getUser().getId().equals(user.getId())||user.getRole().equals(UserRoleEnum.ADMIN)) {
 
             wpRepository.delete(workspace);
             /* 워크스페이스, 보드, 카드, 멤버 등 삭제 */
@@ -54,16 +54,16 @@ public class WpService {
     }
 
     @Transactional(readOnly = true)
-    public WpResponseDto getWorkspace(User wpAuthor, Long Id) {
+    public WpResponseDto getWorkspace(Long Id) {
 
         Workspace workspace = findWorkspace(Id);
         return WpResponseDto.of(workspace);
     }
 
     @Transactional(readOnly = true)
-    public WpsResponseDto getWorkspaces(User wpAuthor) {
+    public WpsResponseDto getWorkspaces(User user) {
 
-        List<Workspace> workspaces = wpRepository.findAllByUserOrderByCreatedAtDesc(wpAuthor);
+        List<Workspace> workspaces = wpRepository.findAllByUserOrderByCreatedAtDesc(user);
         return WpsResponseDto.of(workspaces);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,4 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 
 spring.profiles.include=ds,key,s3
+


### PR DESCRIPTION
## 관련 Issue

* #56 

## 변경 사항

- [x] 초대된 워크스페이스 전체 조회
- [x] 초대된 워크스페이스 단건 조회
- [x] WorkspaceCollaborator Id : 자동 (IDENTITY) -> 수당 할당 (JPA가 merge()하여 초대한 협업자 데이터가 덮어 씌어지는 문제 해결)
- [x] 초대된 보드 전체 조회
- [x] 초대된 보드 단건 조회
- [x] 보드 협업자 추방에서 '해당 기능은 보드를 생성한 사람만 접근할 수 있습니다.' 본인이어도 접근 불가 한 문제 해결

## Todo List
* 초대된 워크스페이스 전체 조회 시, 본인이 속하지 않은 Board는 보이지 않도록 필터링

## Check List

- [x] 포스트맨으로 체크해 보았나요?
* 테스트 코드를 작성하셨나요?

## 트러블 슈팅

* 발생한 예외
1) wpId=1에 최초 워크스페이스 협업자 bojin@naver.com 초대
2) wpId=2에 다음 워크스페이스 협업자 aojin@naver.com 초대

-> 다른 경우에는 모두 요구 사항 대로 작동했으나,  최초 초대 직후 연속으로 초대하는 경우에는 WorkspaceCollaborator 데이터베이스에는 가장 마지막 aojin@naver.com만 남아있는 문제가 발생했으며,

<br>

* 문제 원인
: JPA가 WorkspaceCollaborator Entity가 서로 다른 Entity임을 인식하지 못하고, 같은 Entity를 수정하는 것으로 받아들여 merge()를 수행한 것으로 추정한다. 

<br>

* 해결 시도 01. 이를 예방하기 위해, cascade 설정을 PERSIST로 변경 -> 실패 (덮어 씌워지는 문제가 여전히 발생)

<br>

* 해결 시도 02. Workspace와 매핑되어 있는 List<WorkspaceCollaborator>에 직접적으로 add -> 실패

 ```java
        // 워크스페이스 협업자로 등록
        User foundUser = findUser(email);
        WorkspaceCollaborator newWpCol = WpColRequestDto.toEntity(foundUser, foundWorkspace);

        // 🐥수정한 코드
        foundWorkspace.getWorkspaceCollaborators().add(newWpCol); 
        wpColRepository.save(newWpCol);
```

<br>

* 해결 시도 03. 캐시 문제인지 확인해 보기 위해 entitymanager를 clear -> 실패 
                 .
                 .
                 .
* 실제  해결 방법

```java
@Builder
@Entity
@Getter
@Setter
@NoArgsConstructor
@AllArgsConstructor
public class WorkspaceCollaborator {

    @Id 
    // 🐥수정한 코드
    private Long id;

    private String email;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "user_id", nullable = false)
    private User user;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "workspace_id")
    private Workspace workspace;


    // 🐥수정한 코드

    // ID 수동 할당 메서드
    public void assignNewId() {
        this.id = generateUniqueId();
    }

    public static Long generateUniqueId() {
        return UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;
    }
}
```

```java
@Slf4j
@Service
@RequiredArgsConstructor
public class WpColService {
                 .
                 .
                 .
    // 워크스페이스 협업자 초대 - 보드 협업자로도 자동 초대
    @Transactional
    public void inviteWpCol(User user, Long wpId, String email) {
                                        .
                                        .
                                        .
        // 워크스페이스 협업자로 등록
        User foundUser = findUser(email);
        WorkspaceCollaborator newWpCol = WpColRequestDto.toEntity(foundUser, foundWorkspace);

        // 🐥수정한 코드
        newWpCol.assignNewId();
        wpColRepository.save(newWpCol);
```
