### PR TITLE
[feature] 소셜로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
 }
 
 dependencies {
+    // oauth2
+    implementation 'org.springframework.security:spring-security-oauth2-client'
+
     // h2
     testImplementation 'com.h2database:h2'
 

--- a/src/main/java/com/example/twogether/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/twogether/common/config/WebSecurityConfig.java
@@ -4,17 +4,21 @@ import com.example.twogether.common.jwt.JwtUtil;
 import com.example.twogether.common.security.JwtAuthenticationFilter;
 import com.example.twogether.common.security.JwtAuthorizationFilter;
 import com.example.twogether.common.security.UserDetailsServiceImpl;
+import com.example.twogether.oauth2.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -26,10 +30,16 @@ public class WebSecurityConfig {
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder encoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Bean
@@ -62,8 +72,16 @@ public class WebSecurityConfig {
                 .requestMatchers("api/cards/**").permitAll()
                 .requestMatchers("/api/labels/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/comments/**").permitAll()
-                .anyRequest().authenticated()
+                //.requestMatchers(PathRequest.toStaticResources().atCommonLocations()) // static 아래 정적파일 사용
+                .anyRequest().authenticated()//.permitAll() // 현재 html 사용할 때 permitAll로 풀어야 함
         );
+        //http.formLogin(AbstractHttpConfigurer::disable);
+        //http.oauth2Login().userInfoEndpoint().userService(customOAuth2UserService);
+        //http.oauth2Login(Customizer.withDefaults()).userInfoEndpoint().userService(customOAuth2UserService);
+        //http.oauth2Login(Customizer.withDefaults()).userInfoEndpoint(Customizer.withDefaults());
+        //http.userInfoEndpoint(Customizer.withDefaults());
+        http.oauth2Login(Customizer.withDefaults());
+        //http.userDetailsService((UserDetailsService) customOAuth2UserService);
 
         // 필터 관리
         http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);

--- a/src/main/java/com/example/twogether/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/twogether/common/config/WebSecurityConfig.java
@@ -6,6 +6,7 @@ import com.example.twogether.common.security.JwtAuthorizationFilter;
 import com.example.twogether.common.security.UserDetailsServiceImpl;
 import com.example.twogether.oauth2.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -72,13 +73,13 @@ public class WebSecurityConfig {
                 .requestMatchers("api/cards/**").permitAll()
                 .requestMatchers("/api/labels/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/comments/**").permitAll()
-                //.requestMatchers(PathRequest.toStaticResources().atCommonLocations()) // static 아래 정적파일 사용
-                .anyRequest().authenticated()//.permitAll() // 현재 html 사용할 때 permitAll로 풀어야 함
+                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // static 아래 정적파일 사용
+                .anyRequest().permitAll()//.authenticated()//.permitAll() //.authenticated()// 현재 html 사용할 때 permitAll로 풀어야 함
         );
         //http.formLogin(AbstractHttpConfigurer::disable);
-        //http.oauth2Login().userInfoEndpoint().userService(customOAuth2UserService);
         //http.oauth2Login(Customizer.withDefaults()).userInfoEndpoint().userService(customOAuth2UserService);
-        //http.oauth2Login(Customizer.withDefaults()).userInfoEndpoint(Customizer.withDefaults());
+        //http.oauth2Login(Customizer.withDefaults()).userInfoEndpoint().userService(customOAuth2UserService);
+//        http.oauth2Login(Customizer.withDefaults()).userInfoEndpoint(Customizer.withDefaults());
         //http.userInfoEndpoint(Customizer.withDefaults());
         http.oauth2Login(Customizer.withDefaults());
         //http.userDetailsService((UserDetailsService) customOAuth2UserService);

--- a/src/main/java/com/example/twogether/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/twogether/oauth2/CustomOAuth2UserService.java
@@ -46,7 +46,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     private User saveOrUpdate(OAuthAttributes attributes) {
         User user = userRepository.findByEmail(attributes.getEmail())
-            //.map(entity -> entity.editUserInfo(attributes.getNickname())//,attribute.
+            //.map(entity -> entity.editUserInfo(attributes.getNickname(), get)//,attribute.
             .orElse(attributes.toEntity());
 
         return userRepository.save(user);

--- a/src/main/java/com/example/twogether/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/twogether/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,54 @@
+package com.example.twogether.oauth2;
+
+import com.example.twogether.user.entity.User;
+import com.example.twogether.user.repository.UserRepository;
+import jakarta.servlet.http.HttpSession;
+import java.util.Collections;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+    private final HttpSession httpSession;
+
+    public CustomOAuth2UserService(UserRepository userRepository, HttpSession httpSession) {
+        this.userRepository = userRepository;
+        this.httpSession = httpSession;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        User user = saveOrUpdate(attributes);
+        httpSession.setAttribute("user", new SessionUser(user));
+
+        return new DefaultOAuth2User(
+            Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+            attributes.getAttributes(),
+            attributes.getNameAttributeKey()
+        );
+    }
+
+    private User saveOrUpdate(OAuthAttributes attributes) {
+        User user = userRepository.findByEmail(attributes.getEmail())
+            //.map(entity -> entity.editUserInfo(attributes.getNickname())//,attribute.
+            .orElse(attributes.toEntity());
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/example/twogether/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/example/twogether/oauth2/OAuthAttributes.java
@@ -57,7 +57,7 @@ public class OAuthAttributes {
 
     private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
         Map<String, Object> response = (Map<String, Object>) attributes.get("kakao_account");
-        Map<String, Object> account = (Map<String, Object>) attributes.get("profile");
+        Map<String, Object> account = (Map<String, Object>) response.get("profile");
 
         return OAuthAttributes.builder()
             .nickname((String) account.get("nickname"))
@@ -69,8 +69,9 @@ public class OAuthAttributes {
 
     public User toEntity() {
         return User.builder()
-            .nickname(toEntity().getNickname())
+            .nickname(nickname)
             .email(email)
+            .password("1234")
             .role(UserRoleEnum.USER)
             .build();
     }

--- a/src/main/java/com/example/twogether/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/example/twogether/oauth2/OAuthAttributes.java
@@ -1,0 +1,77 @@
+package com.example.twogether.oauth2;
+
+import com.example.twogether.user.entity.User;
+import com.example.twogether.user.entity.UserRoleEnum;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OAuthAttributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String nickname;
+    private String email;
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        if("naver".equals(registrationId)) {
+            return ofNaver("id", attributes);
+        } else if ("kakao".equals(registrationId)) {
+            return ofKakao("id", attributes);
+        } else if ("facebook".equals(registrationId)) {
+            return ofFacebook("id", attributes);
+        }
+
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+            .nickname((String) attributes.get("nickname"))
+            .email((String) attributes.get("email"))
+            .attributes(attributes)
+            .nameAttributeKey(userNameAttributeName)
+            .build();
+    }
+
+    private static OAuthAttributes ofFacebook(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+            .nickname((String) attributes.get("nickname"))
+            .email((String) attributes.get("email"))
+            .attributes(attributes)
+            .nameAttributeKey(userNameAttributeName)
+            .build();
+    }
+
+    private static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        return OAuthAttributes.builder()
+            .nickname((String) response.get("nickname"))
+            .email((String) response.get("email"))
+            .attributes(response)
+            .nameAttributeKey(userNameAttributeName)
+            .build();
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> account = (Map<String, Object>) attributes.get("profile");
+
+        return OAuthAttributes.builder()
+            .nickname((String) account.get("nickname"))
+            .email((String) response.get("email"))
+            .attributes(response)
+            .nameAttributeKey(userNameAttributeName)
+            .build();
+    }
+
+    public User toEntity() {
+        return User.builder()
+            .nickname(toEntity().getNickname())
+            .email(email)
+            .role(UserRoleEnum.USER)
+            .build();
+    }
+}

--- a/src/main/java/com/example/twogether/oauth2/SessionUser.java
+++ b/src/main/java/com/example/twogether/oauth2/SessionUser.java
@@ -1,0 +1,18 @@
+package com.example.twogether.oauth2;
+
+import com.example.twogether.user.entity.User;
+import java.io.Serializable;
+import lombok.Getter;
+
+@Getter
+public class SessionUser implements Serializable {
+    private String name;
+    private String email;
+    private String introduction;
+
+    public SessionUser(User user){
+        this.name = user.getNickname();
+        this.email = user.getEmail();
+        this.introduction = user.getIntroduction();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,5 +2,5 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update
 
-spring.profiles.include=ds,key,s3
+spring.profiles.include=ds,key,s3,oauth
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,14 +1,11 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <title>Two Gether</title>
+    <meta charset="UTF-8">
+    <title>Two Gether</title>
 </head>
 <body>
-<h1>Hello Two Gether</h1>
-<a href="/oauth2/authorization/google" class="btn btn-success active" role="button">Google Login</a>
-<a href="/oauth2/authorization/facebook" class="btn btn-success active" role="button">Facebook Login</a>
-<a href="/oauth2/authorization/naver" class="btn btn-secondary active" role="button">Naver Login</a>
-<a href="/oauth2/authorization/kakao" class="btn btn-secondary active" role="button">Kakao Login</a>
+<h1>Hello Two Gether!!!</h1>
+<a href="login.html">Log in</a>
 </body>
 </html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Two Gether</title>
+</head>
+<body>
+<h1>Hello Two Gether</h1>
+<a href="/oauth2/authorization/google" class="btn btn-success active" role="button">Google Login</a>
+<a href="/oauth2/authorization/facebook" class="btn btn-success active" role="button">Facebook Login</a>
+<a href="/oauth2/authorization/naver" class="btn btn-secondary active" role="button">Naver Login</a>
+<a href="/oauth2/authorization/kakao" class="btn btn-secondary active" role="button">Kakao Login</a>
+</body>
+</html>

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Two Gether</title>
+</head>
+<body>
+<h1>Hello Two Gether</h1>
+<a href="/oauth2/authorization/google" class="btn btn-success active" role="button">Google Login</a>
+<a href="/oauth2/authorization/facebook" class="btn btn-success active" role="button">Facebook Login</a>
+<a href="/oauth2/authorization/naver" class="btn btn-secondary active" role="button">Naver Login</a>
+<a href="/oauth2/authorization/kakao" class="btn btn-secondary active" role="button">Kakao Login</a>
+</body>
+</html>


### PR DESCRIPTION
## 관련 Issue

* #74 

## 변경 사항


## Todo List

1. 권한 설정
- Resource 안의 파일과 소셜 로그인 url만 접근 허용하고 나머지는 권한 인증 받은 경우 접근 허용 
- 로그인 과정의 url 설정
- http시큐리티 설정

2. 인증 토큰
- 로그인 성공 시 SuccessHandler 로직 백엔드와 프론트엔드 구현
   - 토큰을 발급
   - 토큰 저장
   - 토큰이 유효한지 확인 

3. 로그인 후의 페이지 구현
- 로그인 성공 시 
   - 홈화면으로 이동
   - 구현할 때 1, 2번 관련있음
- 로그인 실패 시
   - 로그인 화면으로 이동

## Check List


## 트러블 슈팅

1. Http시큐리티 관련 설정이 적용이 안됨
(1) requestMatchers() 
권한 관리 대상을 설정하는 메서드가 부분적으로 작동을 안함

권한 관리 대상 지정 URL, HTTP 메소드별로 관리 가능

static 아래 파일들 추가 적용 안됨
```
.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // static 아래 정적파일 사용
```
예를들어 static 폴더 아래 html 등의 파일이 있을 경우 위의 코드를 이용하면 static 폴더 아래 파일들이 권한이 열려 페이지를 사용할 수 있는 코드인데 이 설정이 적용이 안되서 먼저 다음 작업을 하기 위해 두가지 방법을 씀. 

먼저 첫번째는 작업하기 위해 모든 권한을 열어두고 작업 진행.
이 경우 작업할 때만 쓰는거지 인증이나 권한없이 무조건 접근을 허용해서 기존에 시큐리티 권한 설정 작업한 것이 무의미해져서 나중에 쓸 때는 인증된 사용자만 접근을 허용하도록 변경해야 함. 

두번째는 oauth2Login() 메서드를 추가해서 진행.
이경우 oauth 기본 템플릿 페이지는 사용 가능.

* 참고 
아래 코드를 적용했을 때 해당 html 페이지 접근 가능 
```
.requestMatchers(new AntPathRequestMatcher("/index.html")).permitAll()
```


   (2) Cannot resolve method'~~~' in 'HttpSecurity'
```
http
.loginPage("")
.loginProcessingUrl("")
.defaultSuccessUrl("/")
.and() 
.oauth2Login()
.userInfoEndpoint().userService(customOAuth2UserService)
.and()
.successHandler(oAuth2LoginSuccessHandler)
.permitAll()

```

예를 들어 defaultSuccessUrl(login 성공했을 때의 URI에 대한 설정)을 추가하더라도  
Cannot resolve method 'defaultSuccessUrl' in 'HttpSecurity'라고 뜨고 사용할 수 없음



2. 

```
2023-08-28T09:34:30.113+09:00 ERROR 22096 --- [io-8080-exec-10] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception

java.lang.IllegalArgumentException: Missing attribute 'id' in attributes
```